### PR TITLE
fix relative urls to stylesheet, image and toolforge

### DIFF
--- a/tools.inc.php
+++ b/tools.inc.php
@@ -41,7 +41,7 @@ function print_header($lang,$title)
 <head>
  <meta charset="UTF-8" />
  <title>'.$title.'</title></head><body>
- <link rel="stylesheet" type="text/css" href="/stimmberechtigung/style.css" />
+ <link rel="stylesheet" type="text/css" href="/style.css" />
 </head>
 <body>
 ');
@@ -51,7 +51,7 @@ function print_footer($text)
 {
  echo('<hr />
   <div style="float:left;font-size:70%;">'.$text.'</div>
-  <a href="https://tools.wmflabs.org"><img style="float:right;" id="poweredbyicon" src="/stimmberechtigung/powered-by-labs.png" title="Powered by Wikimedia Tool Labs" /></a>
+  <a href="https://toolforge.org"><img style="float:right;" id="poweredbyicon" src="/powered-by-labs.png" title="Powered by Wikimedia Toolforge" /></a>
   </div>
 </body>
 </html>


### PR DESCRIPTION
tools.wmflabs.org/stimmberechtigung have been moved to stimmberechtigung.toolforge.org, therefore relative urls need to be changed to avoid broken look.